### PR TITLE
Prep work for conda install

### DIFF
--- a/remove_dagmc_tags/core.py
+++ b/remove_dagmc_tags/core.py
@@ -9,7 +9,6 @@ from pymoab.types import MBENTITYSET
 
 
 def create_moab_core(input):
-
     moab_core = core.Core()
     moab_core.load_file(str(input))
 
@@ -71,19 +70,16 @@ def remove_tags(
     https://github.com/svalinn/DAGMC-viz source code
 
     Arguments:
-        input: The name of the h5m file to remove the dagmc tags from
+        input: The name of the h5m file to remove the dagmc tags from.
         output: The name of the outfile file(s) with the tags removed.
-            Supported extentions are .vtk and .h5m
-        tags: The tag(S) to be removed.
-        verbose: Print out additional information (True) or not (False)
+            Supported extentions are .vtk and .h5m.
+        tags: The tag(s) to be removed.
+        verbose: Print out additional information (True) or not (False).
 
     Returns:
         filename(s) of the output files produced, names of tags removed, names
-        of all the tags available
+        of all the tags available.
     """
-    if verbose is True:
-        print()
-        print('tags_to_remove', tags)
 
     moab_core, group_categories, tag_name = create_moab_core(input)
 
@@ -93,6 +89,11 @@ def remove_tags(
         tags_to_remove = [tags]
     else:
         tags_to_remove = tags
+
+    if verbose is True:
+        print('\ntag names that will be remove:')
+        for tag in tags_to_remove:
+            print('    ', tag, end='\n\n')
 
     # Find the EntitySet whose name includes tag provided
     sets_to_remove = []
@@ -114,12 +115,12 @@ def remove_tags(
 
     # prints out
     if verbose is True:
-        print()
+        print('tag names found in h5m file:')
         for name in sorted(set(group_names)):
             if str(name.lower()) in tags_to_remove:
-                print(str(name.lower()), ' --- >  Removing tag')
+                print('    ', str(name.lower()), ' ---- >  Removing tag')
             else:
-                print(str(name.lower()))
+                print('    ', str(name.lower()))
         print()
 
     # Remove the EntitySet from the data.
@@ -131,7 +132,7 @@ def remove_tags(
 
     for out in output:
         if verbose is True:
-            print('Writing', out)
+            print('Writing', out, end='\n\n')
         moab_core.write_file(str(out), output_sets=groups_to_write)
 
     return output, names_to_remove, sorted(set(group_names))

--- a/remove_dagmc_tags/remove-dagmc-tags
+++ b/remove_dagmc_tags/remove-dagmc-tags
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '-t', '--tags',
         nargs='*',
-        default=['graveyard'],
+        default=['mat:graveyard'],
         help="The tag or tags to remove."
     )
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="remove_dagmc_tags",
-    version="0.0.3",
+    version="0.0.4",
     author="Svalinn development team",
     description="A tool for selectively removing tags such as the graveyard from DAGMC h5m files.",
     long_description=long_description,
@@ -20,6 +20,9 @@ setuptools.setup(
             "requirements.txt",
             "README.md",
             "LICENSE",
+        ],
+        "tests": [
+            "dagmc.h5m"
         ]
     },
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setuptools.setup(
     },
     install_requires=[
         "numpy"
-        ],
-    #    pymoab is also required for this package but is not available via pip install
+    ],
+    # pymoab is also required for this package but is not available via pip
+    # install
     tests_require=["pytest-cov"],
 )


### PR DESCRIPTION
This PR adds a minimal dagmc.h5m file to the test folder

This is distributed with the pypi package so that conda and run tests during the build process ans mentioned in #4 

Also tidied up the terminal print out and changed the default tag for removal from graveyard to mat:graveyard

just for completeness the minimal dagmc.h5m file was made with the following code

I even tagged one of the materials with the name "vacuum_vessel" just in case that remove all vacuum ever tries to return :-)

```python
import paramak

rotated_block = paramak.RotateStraightShape(
    points=[
        (100, 100),
        (100, -100),
        (50, 0),
    ],
    rotation_angle=90,
    material_tag='vacuum_vessel'
)

extruded_block = paramak.ExtrudeStraightShape(
    points=[
        (150, 150),
        (200, -200),
        (120, 0),
    ],
    distance=90,
    azimuth_placement_angle=45,
    material_tag='extruded_block'
)

cutting_wedge = paramak.CuttingWedgeFS(
    shape=rotated_block,
    material_tag='reflective'
)

reactor = paramak.Reactor([rotated_block, extruded_block, cutting_wedge])

reactor.export_h5m_with_pymoab()

reactor.show()
```
