### PR TITLE
tidy up badges and ownership

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Jonathan Shimwell
+Copyright (c) 2021 the DAGMC development team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![N|Python](https://www.python.org/static/community_logos/python-powered-w-100x40.png)](https://www.python.org)
-[![docker based CI](https://github.com/Shimwell/remove_dagmc_tags/actions/workflows/docker_ci.yml/badge.svg)](https://github.com/Shimwell/remove_dagmc_tags/actions/workflows/docker_ci.yml)
+[![docker based CI](https://github.com/svalinn/remove_dagmc_tags/actions/workflows/docker_ci.yml/badge.svg)](https://github.com/svalinn/remove_dagmc_tags/actions/workflows/docker_ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/remove-dagmc-tags?color=brightgreen&label=pypi&logo=grebrightgreenen&logoColor=green)](https://pypi.org/project/remove-dagmc-tags/)
-[![codecov](https://codecov.io/gh/shimwell/remove_dagmc_tags/branch/main/graph/badge.svg)](https://codecov.io/gh/shimwell/remove_dagmc_tags)
+[![codecov](https://codecov.io/gh/svalinn/remove_dagmc_tags/branch/main/graph/badge.svg)](https://codecov.io/gh/svalinn/remove_dagmc_tags)
 
 This is a minimal Python package that provides both **command line** and **API** interfaces for removing **multiple** tags from a DAGMC h5m file.
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="remove_dagmc_tags",
-    version="0.0.4",
+    version="0.0.5",
     author="DAGMC development team",
     description="A tool for selectively removing tags such as the graveyard from DAGMC h5m files.",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="remove_dagmc_tags",
     version="0.0.4",
-    author="Svalinn development team",
+    author="DAGMC development team",
     description="A tool for selectively removing tags such as the graveyard from DAGMC h5m files.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Just a bit of a tidy up

changing some badges so they point to the new repo and the license so that copyright is with DAGMC development team